### PR TITLE
create a more complex directory example of using hcl templates with Packer

### DIFF
--- a/more_complex/README.md
+++ b/more_complex/README.md
@@ -15,27 +15,27 @@ files:
 
 To run Packer using these templates:
 
-chdir into this directory
+change into this directory
 
-```
+```sh
 cd learn-packer-getting-started/more_complex
 packer init .
 packer build .
 ```
 
-When you call `packer build .` from inside a directory, it loads all the
+When you call `packer build .` from inside a directory, Packer loads all the
 sources, builds, and declared variables and runs all the defined builds in that
 directory.
 
-You can change the variables not to use their default values by pointing the
-builder at a specific -var-file.
+You can change the variables to not use their default values by pointing the
+builder at a specific variables file, using the `-var-file` argument.
 
 ```
 packer build -var-file=dev.pkrvars.hcl .
 ```
 
 This is useful if you have different values you want to use in different
-environments (for example, dev vs prod environments).
+environments (for example, development vs. production environments).
 
 ```
 packer build -var-file=prod.pkrvars.hcl .

--- a/more_complex/README.md
+++ b/more_complex/README.md
@@ -5,13 +5,13 @@ used in Packer builds. Organizing related builds within directories makes it
 easier to reuse code and use variables. Here we split our build into several
 files:
 
-1. "init.pkr.hcl" describes all of our required plugins, required Packer
+1. `init.pkr.hcl` describes all of our required plugins, required Packer
    version, etc.
-1. "variables.pkr.hcl" declares all of the variables we will use.
-1. "dev.pkrvars.hcl" declares a set of possible values for the variables declared in "variables.pkr.hcl"
-1. "prod.pkrvars.hcl" declares another set of possible values for the variables declared in "variables.pkr.hcl"
-1. "sources.pkr.hcl" defines our sources
-1. "build.pkr.hcl" defines a build
+1. `variables.pkr.hcl` declares all of the variables we will use.
+1. `dev.pkrvars.hcl` declares a set of possible values for the variables declared in "variables.pkr.hcl"
+1. `prod.pkrvars.hcl` declares another set of possible values for the variables declared in "variables.pkr.hcl"
+1. `sources.pkr.hcl` defines our sources
+1. `build.pkr.hcl` defines a build
 
 To run Packer using these templates:
 

--- a/more_complex/README.md
+++ b/more_complex/README.md
@@ -1,0 +1,42 @@
+# A more Complex Example
+
+This example is designed to show you how to lay out a directory that can be
+used in Packer builds. Organizing related builds within directories makes it
+easier to reuse code and use variables. Here we split our build into several
+files:
+
+1. "init.pkr.hcl" describes all of our required plugins, required Packer
+   version, etc.
+1. "variables.pkr.hcl" declares all of the variables we will use.
+1. "dev.pkrvars.hcl" declares a set of possible values for the variables declared in "variables.pkr.hcl"
+1. "prod.pkrvars.hcl" declares another set of possible values for the variables declared in "variables.pkr.hcl"
+1. "sources.pkr.hcl" defines our sources
+1. "build.pkr.hcl" defines a build
+
+To run Packer using these templates:
+
+chdir into this directory
+
+```
+cd learn-packer-getting-started/more_complex
+packer init .
+packer build .
+```
+
+When you call `packer build .` from inside a directory, it loads all the
+sources, builds, and declared variables and runs all the defined builds in that
+directory.
+
+You can change the variables not to use their default values by pointing the
+builder at a specific -var-file.
+
+```
+packer build -var-file=dev.pkrvars.hcl .
+```
+
+This is useful if you have different values you want to use in different
+environments (for example, dev vs prod environments).
+
+```
+packer build -var-file=prod.pkrvars.hcl .
+```

--- a/more_complex/build.pkr.hcl
+++ b/more_complex/build.pkr.hcl
@@ -1,0 +1,23 @@
+// Here we're loading sources defined in sources.pkr.hcl
+
+build {
+  sources = [
+    "source.docker.example-2",
+    "source.docker.example",
+    "source.null.example-3",
+  ]
+  provisioner "shell" {
+    // the shell provisioner wouldn't work with the null builder, so we skip it
+    // using this except field
+    except = ["null.example-3"]
+    environment_vars = [
+      "FLAVOR=${var.flavor}",
+    ]
+    inline = [
+      "echo \"My favorite ice cream is $FLAVOR\"",
+    ]
+  }
+  provisioner "shell-local" {
+    inline = ["echo welcome to Packer!"]
+  }
+}

--- a/more_complex/dev.pkrvars.hcl
+++ b/more_complex/dev.pkrvars.hcl
@@ -1,0 +1,1 @@
+flavor = "chocolate"

--- a/more_complex/init.pkr.hcl
+++ b/more_complex/init.pkr.hcl
@@ -1,0 +1,11 @@
+// for more information about packer initialization, see
+// https://www.packer.io/docs/commands/init
+
+packer {
+  required_plugins {
+    docker = {
+      version = ">= 0.0.7"
+      source = "github.com/hashicorp/docker"
+    }
+  }
+}

--- a/more_complex/prod.pkrvars.hcl
+++ b/more_complex/prod.pkrvars.hcl
@@ -1,0 +1,1 @@
+flavor = "strawberry"

--- a/more_complex/sources.pkr.hcl
+++ b/more_complex/sources.pkr.hcl
@@ -1,0 +1,19 @@
+// These builder sources will be used in build.pkr.hcl
+
+source "docker" "example" {
+  image  = "ubuntu:xenial"
+  commit = true
+}
+
+source "docker" "example-2" {
+  image  = "ubuntu:bionic"
+  commit = true
+}
+
+// Null builders create no resources and store no artifacts. They are useful for
+// debugging build flow, but are very limited in terms of practical use and
+// don't work with most provisioners since there isn't anyting created for them
+// to provision
+source "null" "example-3" {
+  communicator = "none"
+}

--- a/more_complex/variables.pkr.hcl
+++ b/more_complex/variables.pkr.hcl
@@ -1,4 +1,4 @@
 variable "flavor" {
-  type = string
+  type     = string
   default = "vanilla"
 }

--- a/more_complex/variables.pkr.hcl
+++ b/more_complex/variables.pkr.hcl
@@ -1,0 +1,4 @@
+variable "flavor" {
+  type = string
+  default = "vanilla"
+}


### PR DESCRIPTION
This is another example that shows how to use several HCL files together to define a Packer build. 